### PR TITLE
Allow for parsing larger intergers in Period strings

### DIFF
--- a/period/parse.go
+++ b/period/parse.go
@@ -147,6 +147,6 @@ func parseDecimalFixedPoint(s, original string) (int16, error) {
 		s = s + "0"
 	}
 
-	n, e := strconv.ParseInt(s, 10, 16)
+	n, e := strconv.ParseInt(s, 10, 32)
 	return int16(n), e
 }


### PR DESCRIPTION
I recently was parsing numerous ISO-8601 strings with this library, but one string failed with a mysterious error: `expected a number before the 'S' marker: PT31536000S`.

I debugged the code and realized that the problem wasn't a malformed ISO-8601 string, but the fact that `strconv.ParseInt` was called in `date/period.parseDecimalFixedPoint()` with a bitsize of 16. This meant the integer 31536000 overflowed the 16 bit size, so increasing the bitsize to 32 solved the issue.

I'm not sure if there was a specific reason you used a 16 bitsize, I'm just making a PR because it's an easy fix and I you can't submit an issue to forks :/. 