### PR TITLE
feat: add period.ParseWithNormalise

### DIFF
--- a/period/parse.go
+++ b/period/parse.go
@@ -33,6 +33,24 @@ func MustParse(value string) Period {
 // are equivalent: "P0Y", "P0M", "P0W", "P0D", "PT0H", PT0M", PT0S", and "P0".
 // The canonical zero is "P0D".
 func Parse(period string) (Period, error) {
+	return ParseWithNormalise(period, true)
+}
+
+// ParseWithNormalise parses strings that specify periods using ISO-8601 rules
+// with an option to specify whether to normalise parsed period components.
+//
+// In addition, a plus or minus sign can precede the period, e.g. "-P10D"
+
+// The returned value is only normalised when normalise is set to `true`, and
+// normalisation will convert e.g. multiple of 12 months into years so "P24M"
+// is the same as "P2Y". However, this is done without loss of precision, so
+// for example whole numbers of days do not contribute to the months tally
+// because the number of days per month is variable.
+//
+// The zero value can be represented in several ways: all of the following
+// are equivalent: "P0Y", "P0M", "P0W", "P0D", "PT0H", PT0M", PT0S", and "P0".
+// The canonical zero is "P0D".
+func ParseWithNormalise(period string, normalise bool) (Period, error) {
 	if period == "" {
 		return Period{}, fmt.Errorf("cannot parse a blank string as a period")
 	}
@@ -111,7 +129,11 @@ func Parse(period string) (Period, error) {
 		return Period{}, fmt.Errorf("expected 'Y', 'M', 'W', 'D', 'H', 'M', or 'S' marker: %s", period)
 	}
 
-	return result.normalise64(true).toPeriod(), nil
+	if normalise {
+		return result.normalise64(true).toPeriod(), nil
+	}
+
+	return result.toPeriod(), nil
 }
 
 type parseState struct {

--- a/period/period_test.go
+++ b/period/period_test.go
@@ -39,53 +39,59 @@ func TestParseErrors(t *testing.T) {
 	}
 }
 
-func TestParsePeriod(t *testing.T) {
+func TestParsePeriodWithNormalise(t *testing.T) {
 	cases := []struct {
-		value  string
-		period Period
+		value     string
+		normalise bool
+		period    Period
 	}{
-		{"P0", Period{}},
-		{"P0Y", Period{}},
-		{"P0M", Period{}},
-		{"P0D", Period{}},
-		{"PT0H", Period{}},
-		{"PT0M", Period{}},
-		{"PT0S", Period{}},
-		{"P3Y", Period{30, 0, 0, 0, 0, 0}},
-		{"P6M", Period{0, 60, 0, 0, 0, 0}},
-		{"P5W", Period{0, 0, 350, 0, 0, 0}},
-		{"P4D", Period{0, 0, 40, 0, 0, 0}},
-		{"PT12H", Period{0, 0, 0, 120, 0, 0}},
-		{"PT30M", Period{0, 0, 0, 0, 300, 0}},
-		{"PT25S", Period{0, 0, 0, 0, 0, 250}},
-		{"PT30M67.6S", Period{0, 0, 0, 0, 310, 76}},
-		{"P3Y6M5W4DT12H40M5S", Period{30, 60, 390, 120, 400, 50}},
-		{"+P3Y6M5W4DT12H40M5S", Period{30, 60, 390, 120, 400, 50}},
-		{"-P3Y6M5W4DT12H40M5S", Period{-30, -60, -390, -120, -400, -50}},
-		{"P2.Y", Period{20, 0, 0, 0, 0, 0}},
-		{"P2.5Y", Period{25, 0, 0, 0, 0, 0}},
-		{"P2.15Y", Period{21, 0, 0, 0, 0, 0}},
-		{"P2.125Y", Period{21, 0, 0, 0, 0, 0}},
-		{"P1Y2.M", Period{10, 20, 0, 0, 0, 0}},
-		{"P1Y2.5M", Period{10, 25, 0, 0, 0, 0}},
-		{"P1Y2.15M", Period{10, 21, 0, 0, 0, 0}},
-		{"P1Y2.125M", Period{10, 21, 0, 0, 0, 0}},
-		{"P3276.7Y", Period{32767, 0, 0, 0, 0, 0}},
-		{"-P3276.7Y", Period{-32767, 0, 0, 0, 0, 0}},
+		{"P0", true, Period{}},
+		{"P0Y", true, Period{}},
+		{"P0M", true, Period{}},
+		{"P0D", true, Period{}},
+		{"PT0H", true, Period{}},
+		{"PT0M", true, Period{}},
+		{"PT0S", true, Period{}},
+		{"P3Y", true, Period{30, 0, 0, 0, 0, 0}},
+		{"P6M", true, Period{0, 60, 0, 0, 0, 0}},
+		{"P5W", true, Period{0, 0, 350, 0, 0, 0}},
+		{"P4D", true, Period{0, 0, 40, 0, 0, 0}},
+		{"PT12H", true, Period{0, 0, 0, 120, 0, 0}},
+		{"PT30M", true, Period{0, 0, 0, 0, 300, 0}},
+		{"PT25S", true, Period{0, 0, 0, 0, 0, 250}},
+		{"PT30M67.6S", true, Period{0, 0, 0, 0, 310, 76}},
+		{"P3Y6M5W4DT12H40M5S", true, Period{30, 60, 390, 120, 400, 50}},
+		{"+P3Y6M5W4DT12H40M5S", true, Period{30, 60, 390, 120, 400, 50}},
+		{"-P3Y6M5W4DT12H40M5S", true, Period{-30, -60, -390, -120, -400, -50}},
+		{"P2.Y", true, Period{20, 0, 0, 0, 0, 0}},
+		{"P2.5Y", true, Period{25, 0, 0, 0, 0, 0}},
+		{"P2.15Y", true, Period{21, 0, 0, 0, 0, 0}},
+		{"P2.125Y", true, Period{21, 0, 0, 0, 0, 0}},
+		{"P1Y2.M", true, Period{10, 20, 0, 0, 0, 0}},
+		{"P1Y2.5M", true, Period{10, 25, 0, 0, 0, 0}},
+		{"P1Y2.15M", true, Period{10, 21, 0, 0, 0, 0}},
+		{"P1Y2.125M", true, Period{10, 21, 0, 0, 0, 0}},
+		{"P3276.7Y", true, Period{32767, 0, 0, 0, 0, 0}},
+		{"-P3276.7Y", true, Period{-32767, 0, 0, 0, 0, 0}},
 		// largest possible number of seconds normalised only in hours, mins, sec
-		{"PT11592000S", Period{0, 0, 0, 32200, 0, 0}},
-		{"-PT11592000S", Period{0, 0, 0, -32200, 0, 0}},
-		{"PT11595599S", Period{0, 0, 0, 32200, 590, 590}},
+		{"PT11592000S", true, Period{0, 0, 0, 32200, 0, 0}},
+		{"-PT11592000S", true, Period{0, 0, 0, -32200, 0, 0}},
+		{"PT11595599S", true, Period{0, 0, 0, 32200, 590, 590}},
 		// largest possible number of seconds normalised only in days, hours, mins, sec
-		{"PT283046400S", Period{0, 0, 32760, 0, 0, 0}},
-		{"-PT283046400S", Period{0, 0, -32760, 0, 0, 0}},
-		{"PT283132799S", Period{0, 0, 32760, 230, 590, 590}},
+		{"PT283046400S", true, Period{0, 0, 32760, 0, 0, 0}},
+		{"-PT283046400S", true, Period{0, 0, -32760, 0, 0, 0}},
+		{"PT283132799S", true, Period{0, 0, 32760, 230, 590, 590}},
 		// largest possible number of months
-		{"P39312M", Period{32760, 0, 0, 0, 0, 0}},
-		{"-P39312M", Period{-32760, 0, 0, 0, 0, 0}},
+		{"P39312M", true, Period{32760, 0, 0, 0, 0, 0}},
+		{"-P39312M", true, Period{-32760, 0, 0, 0, 0, 0}},
+		// without normalisation
+		{"P1Y14M35DT48H125M800S", false, Period{10, 140, 350, 480, 1250, 8000}},
 	}
 	for i, c := range cases {
-		d := MustParse(c.value)
+		d, err := ParseWithNormalise(c.value, c.normalise)
+		if err != nil {
+			panic(err)
+		}
 		if d != c.period {
 			t.Errorf("%d: MustParse(%v) == %#v, want (%#v)", i, c.value, d, c.period)
 		}


### PR DESCRIPTION
This PR adds a `period.ParseWithNormalise` function that enables the caller to specify whether the returned period should be normalised or not.

resolves #6.